### PR TITLE
mst-parser uses "case" to handle different modes

### DIFF
--- a/opencog/nlp/learn/scm/mst-parser.scm
+++ b/opencog/nlp/learn/scm/mst-parser.scm
@@ -210,10 +210,10 @@
 	; Define where the costs are coming from.
 	(define pair-obj 
 		(cond 
-			((equal? cnt-mode "any") (make-any-link-api))
 			((or (equal? cnt-mode "clique")
 			     (equal? cnt-mode "clique-dist"))
-			      	(make-clique-pair-api))))
+			      	(make-clique-pair-api))
+			(else (make-any-link-api))))
 
 	(define mi-source (add-pair-freq-api pair-obj))
 

--- a/opencog/nlp/learn/scm/mst-parser.scm
+++ b/opencog/nlp/learn/scm/mst-parser.scm
@@ -211,7 +211,9 @@
 	(define pair-obj 
 		(cond 
 			((equal? cnt-mode "any") (make-any-link-api))
-			(else make-clique-pair-api)))
+			((or (equal? cnt-mode "clique")
+			     (equal? cnt-mode "clique-dist"))
+			      	(make-clique-pair-api))))
 
 	(define mi-source (add-pair-freq-api pair-obj))
 


### PR DESCRIPTION
mst-parser uses "case" to handle different modes