### PR TITLE
Optional splitter

### DIFF
--- a/opencog/nlp/learn/run-ull/README.md
+++ b/opencog/nlp/learn/run-ull/README.md
@@ -647,7 +647,7 @@ Before you follow the next steps make sure you have cloned the repositories from
 
    c) Send input to the pipeline:
    ```
-    $ echo -e "(observe-text \"This is a test\" \"any\" 24)" |nc localhost 17005
+    $ echo -e "(observe-text-mode \"This is a test\" \"any\" 24)" |nc localhost 17005
    ```
 
    d) Check that the input was registered in the database:

--- a/opencog/nlp/learn/run-ull/config/params.txt
+++ b/opencog/nlp/learn/run-ull/config/params.txt
@@ -2,7 +2,8 @@
 #       variable_name=value	#possibilities
 
 export cnt_mode="clique-dist" 	 # clique, clique-dist or any
-export cnt_reach=6		 # num-parses for any, or win-size for clique
-export mst_dist="#t"		 # #t or #f
-export exp_parses="#t"  	 # #t or #f
+export cnt_reach=6		 # num-parses for any, or win-size for cliques
+export mst_dist="#t"		 # #t or #f; use distance weight during mst
+export exp_parses="#t"  	 # #t or #f; exports parses in folder mst-parses
+export split_sents="#t"		 # #t or #f; calls sentence splitter before parser
 #TODO export store_fmi="#t"	# #t or #f 

--- a/opencog/nlp/learn/run-ull/process-one.sh
+++ b/opencog/nlp/learn/run-ull/process-one.sh
@@ -24,6 +24,7 @@ cnt_mode="clique-dist"
 cnt_reach=6
 mst_dist="#t"
 exp_parses="#t"
+split_sents="#t"
 source ./config/params.txt # overrides default values, if present
 
 # Split the filename into two parts
@@ -60,8 +61,12 @@ echo "Processing file >>>$rest<<<"
 mkdir -p $(dirname "$splitdir/$rest")
 mkdir -p $(dirname "$subdir/$rest")
 
-# Sentence split the article itself
-cat "$filename" | $splitter -l $lang >  "$splitdir/$rest"
+# Sentence split the article itself if requested
+if [[ "$split_sents" == "#t" ]]; then
+   cat "$filename" | $splitter -l $lang >  "$splitdir/$rest"
+else # escape double quotes and backslashes if not split-sentence
+   cat "$filename" | sed -e 's/\\/\\\\' -e 's/\"/\\\"' > "$splitdir/$rest"
+fi
 
 # Submit the split article
 cat "$splitdir/$rest" | ./submit-one.pl $coghost $cogport $observe $params

--- a/opencog/nlp/learn/run-ull/process-one.sh
+++ b/opencog/nlp/learn/run-ull/process-one.sh
@@ -65,7 +65,7 @@ mkdir -p $(dirname "$subdir/$rest")
 if [[ "$split_sents" == "#t" ]]; then
    cat "$filename" | $splitter -l $lang >  "$splitdir/$rest"
 else # escape double quotes and backslashes if not split-sentence
-   cat "$filename" | sed -e 's/\\/\\\\' -e 's/\"/\\\"' > "$splitdir/$rest"
+   cat "$filename" | sed -e 's/\\/\\\\/g' -e 's/\"/\\\"/g' > "$splitdir/$rest"
 fi
 
 # Submit the split article


### PR DESCRIPTION
For ULL experiments, made the sentence-splitter optional (it is active by default), as the pre-cleaner has already pre-split the text.