### PR TITLE
Update the Ghost parser to support comparison operators

### DIFF
--- a/opencog/ghost/README.md
+++ b/opencog/ghost/README.md
@@ -53,6 +53,15 @@ There are different types of rules in ChatScript -- responders (`u:` `s:` `?:`) 
 
 [Rejoinder](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#fast-overview-of-topic-files-top) (`a:` to `q:`) is also supported. Rejoinders have a higher priority than responders and gambits so it will always be selected if it satisfies the context. If more than one rejoinders satisfy the current context, the one that's defined first will always be selected.
 
+Simple comparisons (`=` `!=` `<` `<=` `>` `>=`) can be done in the context of a rule, for variables, user variables, and functions, e.g.
+```
+(^get_arousal() > 0)
+
+(you are _* '_0!=lazy)
+
+(^get_value() <= $threshold)
+```
+
 The action selection in GHOST is goal-driven, so all of the GHOST rules should be linked to one or more goals. You can link more than one goal to a rule, just like defining concepts, use a space to separate them. The value assigned to a goal will affect the strength of the rules (`ImplicationLinks`) linked to that goal.
 
 There are two ways of creating goals,
@@ -158,13 +167,15 @@ agents-start opencog::AFImportanceDiffusionAgent opencog::WAImportanceDiffusionA
 
 Note, rules being created after running this will be slimmer (preferred) and can only work with this ECAN approach. They are NOT backward-compatible with the `test-ghost`.
 
-8) Start authoring, e.g.
+8) Start authoring by creating rules in a text file, e.g.
 
 ```
-(ghost-parse "#goal: (novelty=0.24) u: (eat apple) I want an apple")
+#goal: (novelty=0.24)
+
+u: (eat apple) I want an apple
 ```
 
-Or use `ghost-parse-files` to parse rule files.
+Then use `ghost-parse-files` to parse rule file(s).
 
 ```
 (ghost-parse-files "path/to/the/rule/file1" "path/to/the/rule/file2")

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -38,7 +38,9 @@
 (define (tokeniz str location)
   (define current-match '())
   (define (has-match? pattern str)
-    (let ((match (string-match pattern str)))
+    (let ((match
+            (string-match
+              (string-append "^[ \t]*" pattern) str)))
       (if match
         (begin (set! current-match match) #t)
         #f
@@ -63,110 +65,110 @@
   ; 2. #f is given as a token value for those cases which don't have any
   ;    semantic values.
   (cond
-    ((has-match? "^[ ]*\\([ \t]*" str) (result:suffix 'LPAREN location #f))
-    ((has-match? "^[ ]*\\)[ \t]*" str) (result:suffix 'RPAREN location #f))
+    ((has-match? "\\(" str) (result:suffix 'LPAREN location #f))
+    ((has-match? "\\)" str) (result:suffix 'RPAREN location #f))
     ; Chatscript declarations
-    ((has-match? "^[ ]*concept:" str) (result:suffix 'CONCEPT location #f))
-    ((has-match? "^[ ]*topic:" str) (result:suffix 'TOPIC location #f))
+    ((has-match? "concept:" str) (result:suffix 'CONCEPT location #f))
+    ((has-match? "topic:" str) (result:suffix 'TOPIC location #f))
     ; The token value for 'CR is empty-string so as to handle multiline
     ; rules.
-    ((has-match? "^[ ]*\r" str) (result:suffix 'CR location ""))
+    ((has-match? "\r" str) (result:suffix 'CR location ""))
     ; FIXME: This is not really newline.
     ((string=? "" str) (cons (make-lexical-token 'NEWLINE location #f) ""))
-    ((has-match? "^[ \t]*urge:" str) (result:suffix 'URGE location #f))
-    ((has-match? "^[ \t]*ordered-goal:" str) (result:suffix 'ORD-GOAL location #f))
-    ((has-match? "^[ \t]*goal:" str) (result:suffix 'GOAL location #f))
-    ((has-match? "^[ \t]*#goal:" str) (result:suffix 'RGOAL location #f))
-    ((has-match? "^[ \t]*#!" str) ; This should be checked always before #
+    ((has-match? "urge:" str) (result:suffix 'URGE location #f))
+    ((has-match? "ordered-goal:" str) (result:suffix 'ORD-GOAL location #f))
+    ((has-match? "goal:" str) (result:suffix 'GOAL location #f))
+    ((has-match? "#goal:" str) (result:suffix 'RGOAL location #f))
+    ((has-match? "#!" str) ; This should be checked always before #
       ; TODO Add tester function for this
       (cons (make-lexical-token 'SAMPLE_INPUT location #f) ""))
-    ((has-match? "^[ \t]*#" str)
+    ((has-match? "*#" str)
       (cons (make-lexical-token 'COMMENT location #f) ""))
     ; Chatscript rules
-    ((has-match? "^[ ]*[s?u]:" str)
+    ((has-match? "[s?u]:" str)
       (result:suffix 'RESPONDERS location
         (car (string->list (substring (string-trim
           (match:substring current-match)) 0 1)))))
-    ((has-match? "^[ \t]*[a-q]:" str)
+    ((has-match? "[a-q]:" str)
       (result:suffix 'REJOINDERS location
         (car (string->list (substring (string-trim
           (match:substring current-match)) 0 1)))))
-    ((has-match? "^[ ]*[rt]:" str)
+    ((has-match? "[rt]:" str)
       (result:suffix 'GAMBIT location
         (car (string->list (substring (string-trim
           (match:substring current-match)) 0 1)))))
-    ((has-match? "^[ ]*[{][%] set delay=[0-9]+ [%][}]" str)
+    ((has-match? "[{][%] set delay=[0-9]+ [%][}]" str)
       (result:suffix 'SET_DELAY location
         (string-trim (match:substring current-match))))
-    ((has-match? "^[ ]*_[0-9]" str)
+    ((has-match? "_[0-9]" str)
       (result:suffix 'MVAR location
         (substring (string-trim (match:substring current-match)) 1)))
-    ((has-match? "^[ ]*'_[0-9]" str)
+    ((has-match? "'_[0-9]" str)
       (result:suffix 'MOVAR location
         (substring (string-trim (match:substring current-match)) 2)))
-    ((has-match? "^[ ]*\\$[a-zA-Z0-9_-]+" str)
+    ((has-match? "\\$[a-zA-Z0-9_-]+" str)
       (result:suffix 'UVAR location
         (substring (string-trim (match:substring current-match)) 1)))
-    ((has-match? "^[ ]*_" str) (result:suffix 'VAR location #f))
+    ((has-match? "_" str) (result:suffix 'VAR location #f))
     ; For dictionary keyword sets
-    ((has-match? "^[ ]*[a-zA-Z]+~[a-zA-Z1-9]+" str)
+    ((has-match? "[a-zA-Z]+~[a-zA-Z1-9]+" str)
       (result:suffix 'DICTKEY location (command-pair)))
     ; Range-restricted Wildcards.
     ; TODO Maybe replace with dictionary keyword sets then process it on action?
-    ((has-match? "^[ ]*\\*~[0-9]+" str)
+    ((has-match? "\\*~[0-9]+" str)
       (result:suffix '*~n location
         (substring (string-trim (match:substring current-match)) 2)))
-    ((has-match? "^[ ]*~[a-zA-Z0-9_]+" str)
+    ((has-match? "~[a-zA-Z0-9_]+" str)
       (result:suffix 'ID location
         (substring (string-trim (match:substring current-match)) 1)))
-    ((has-match? "^[ ]*\\^" str) (result:suffix '^ location #f))
-    ((has-match? "^[ ]*\\[" str) (result:suffix 'LSBRACKET location #f))
-    ((has-match? "^[ ]*]" str) (result:suffix 'RSBRACKET location #f))
-    ((has-match? "^[ ]*\\{" str) (result:suffix 'LBRACE location #f))
-    ((has-match? "^[ ]*}" str) (result:suffix 'RBRACE location #f))
-    ((has-match? "^[ ]*<<" str) (result:suffix '<< location #f))
-    ((has-match? "^[ ]*>>" str) (result:suffix '>> location #f))
+    ((has-match? "\\^" str) (result:suffix '^ location #f))
+    ((has-match? "\\[" str) (result:suffix 'LSBRACKET location #f))
+    ((has-match? "]" str) (result:suffix 'RSBRACKET location #f))
+    ((has-match? "\\{" str) (result:suffix 'LBRACE location #f))
+    ((has-match? "}" str) (result:suffix 'RBRACE location #f))
+    ((has-match? "<<" str) (result:suffix '<< location #f))
+    ((has-match? ">>" str) (result:suffix '>> location #f))
     ; For restarting matching position -- "< *"
-    ((has-match? "^[ ]*<[ ]*\\*" str) (result:suffix 'RESTART location #f))
+    ((has-match? "<[ ]*\\*" str) (result:suffix 'RESTART location #f))
     ; This should follow <<
-    ((has-match? "^[ ]*<" str) (result:suffix '< location #f))
+    ((has-match? "<" str) (result:suffix '< location #f))
     ; This should follow >>
-    ((has-match? "^[ ]*>" str) (result:suffix '> location #f))
-    ((has-match? "^[ ]*\"" str) (result:suffix 'DQUOTE location "\""))
+    ((has-match? ">" str) (result:suffix '> location #f))
+    ((has-match? "\"" str) (result:suffix 'DQUOTE location "\""))
     ; Precise wildcards
-    ((has-match? "^[ ]*\\*[0-9]+" str) (result:suffix '*n location
+    ((has-match? "\\*[0-9]+" str) (result:suffix '*n location
        (substring (string-trim (match:substring current-match)) 1)))
     ; Wildcards
-    ((has-match? "^[ ]*\\*" str) (result:suffix '* location "*"))
-    ((has-match? "^[ ]*!" str) (result:suffix 'NOT location #f))
-    ((has-match? "^[ ]*[?]" str) (result:suffix '? location "?"))
-    ((has-match? "^[ ]*=" str) (result:suffix 'EQUAL location #f))
+    ((has-match? "\\*" str) (result:suffix '* location "*"))
+    ((has-match? "!" str) (result:suffix 'NOT location #f))
+    ((has-match? "[?]" str) (result:suffix '? location "?"))
+    ((has-match? "=" str) (result:suffix 'EQUAL location #f))
     ; Words with apostrophe, e.g. I'm, it's etc
-    ((has-match? "^[ ]*[a-zA-Z]+['’][a-zA-Z]+" str)
+    ((has-match? "[a-zA-Z]+['’][a-zA-Z]+" str)
       (result:suffix 'LITERAL_APOS location
         (string-trim (match:substring current-match))))
     ; Literals -- words start with a '
-    ((has-match? "^[ ]*'[a-zA-Z]+\\b" str)
+    ((has-match? "'[a-zA-Z]+\\b" str)
       (result:suffix 'LITERAL location
         (substring (string-trim (match:substring current-match)) 1)))
-    ((has-match? "^[ ]*[a-zA-Z-]+\\b" str)
+    ((has-match? "[a-zA-Z-]+\\b" str)
       (if (is-lemma? (string-trim (match:substring current-match)))
         (result:suffix 'LEMMA location
           (string-trim (match:substring current-match)))
         ; Literals, words in the pattern that are not in their canonical forms
         (result:suffix 'LITERAL location
           (string-trim (match:substring current-match)))))
-    ((has-match? "^[ ]*[0-9]+[0-9.]*" str)
+    ((has-match? "[0-9]+[0-9.]*" str)
       (result:suffix 'NUM location
         (string-trim (match:substring current-match))))
-    ((has-match? "^[ ]*[|]" str)
+    ((has-match? "[|]" str)
       (result:suffix 'VLINE location
          (string-trim (match:substring current-match))))
-    ((has-match? "^[ ]*," str)
+    ((has-match? "," str)
       (result:suffix 'COMMA location
          (string-trim (match:substring current-match))))
     ; This should always be near the end, because it is broadest of all.
-    ((has-match? "^[ \t]*[~’'._!?0-9a-zA-Z-]+" str)
+    ((has-match? "[~’'._!?0-9a-zA-Z-]+" str)
       (result:suffix 'STRING location
         (string-trim (match:substring current-match))))
     ; Trailing space

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -63,8 +63,8 @@
   ; 2. #f is given as a token value for those cases which don't have any
   ;    semantic values.
   (cond
-    ((has-match? "^[ ]*\\(" str) (result:suffix 'LPAREN location #f))
-    ((has-match? "^[ ]*\\)" str) (result:suffix 'RPAREN location #f))
+    ((has-match? "^[ ]*\\([ \t]*" str) (result:suffix 'LPAREN location #f))
+    ((has-match? "^[ ]*\\)[ \t]*" str) (result:suffix 'RPAREN location #f))
     ; Chatscript declarations
     ((has-match? "^[ ]*concept:" str) (result:suffix 'CONCEPT location #f))
     ((has-match? "^[ ]*topic:" str) (result:suffix 'TOPIC location #f))

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -574,12 +574,19 @@
     (variable-grounding
       (MVAR) : (format #f "(cons 'get_lvar ~a)" $1)
       (MOVAR) : (format #f "(cons 'get_wvar ~a)" $1)
+      (MVAR operator right-compare) :
+        (format #f "(cons 'compare (list \"~a\" ~a ~a))"
+          $2 (format #f "(cons 'get_lvar ~a)" $1) $3)
+      (MOVAR operator right-compare) :
+        (format #f "(cons 'compare (list \"~a\" ~a ~a))"
+          $2 (format #f "(cons 'get_wvar ~a)" $1) $3)
     )
 
     (user-variable
       (UVAR) : (format #f "(cons 'uvar_exist \"~a\")" $1)
-      (UVAR EQUAL name) :
-        (format #f "(cons 'uvar_equal (list \"~a\" \"~a\"))" $1 $3)
+      (UVAR operator right-compare) :
+        (format #f "(cons 'compare (list \"~a\" ~a ~a))"
+          $2 (format #f "(cons 'get_uvar \"~a\")" $1) $3)
     )
 
     (negation
@@ -706,6 +713,23 @@
       (COMMA) : ""
       (name) : (format #f "(cons 'str \"~a\")" $1)
       (UVAR) : (format #f "(cons 'get_uvar \"~a\")" $1)
+    )
+
+    (right-compare
+      (UVAR) : (format #f "(cons 'get_uvar \"~a\")" $1)
+      (name) : (format #f "(cons 'str \"~a\")" $1)
+      (DQUOTE phrase-terms DQUOTE) : (format #f "(cons 'str \"~a\")" $2)
+      (concept) : $1
+      (function) : $1
+    )
+
+    (operator
+      (<) : "smaller"
+      (>) : "greater"
+      (EQUAL) : "equal"
+      (< EQUAL) : "smaller_equal"
+      (> EQUAL) : "greater_equal"
+      (NOT EQUAL) : "not_equal"
     )
   )
 )

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -455,6 +455,7 @@
       (variable) : $1
       (user-variable) : $1
       (function) : $1
+      (function-compare) : $1
       (choice) : $1
       (optional) : $1
       (variable ? concept) :
@@ -606,6 +607,11 @@
       (literal-apos) : $1
       (phrase) : $1
       (concept) : $1
+    )
+
+    (function-compare
+      (function operator right-compare) :
+        (format #f "(cons 'compare (list \"~a\" ~a ~a))" $2 $1 $3)
     )
 
     (function

--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -238,6 +238,21 @@
 )
 
 ;; --------------------
+(define (clear-parsing-states)
+  (set! rule-topic '())
+  (set! initial-urges '())
+  (set! default-urge 0)
+  (set! top-lv-goals '())
+  (set! is-rule-seq? #f)
+  (set! goal-rule-cnt 0)
+  (set! pat-vars '())
+  (set! rule-label-list '())
+  (set! rule-type-alist '())
+  (set! rule-alist '())
+  (set! rule-hierarchy '())
+)
+
+;; --------------------
 ;; To parse rules and interact with GHOST, the main interfaces
 
 (define-public (ghost-parse TXT)

--- a/opencog/ghost/ghost.scm
+++ b/opencog/ghost/ghost.scm
@@ -134,6 +134,21 @@
 ; Will be used when dealing with rejoinders
 (define rule-hierarchy '())
 
+; To clear the above states
+(define (clear-parsing-states)
+  (set! rule-topic '())
+  (set! initial-urges '())
+  (set! default-urge 0)
+  (set! top-lv-goals '())
+  (set! is-rule-seq? #f)
+  (set! goal-rule-cnt 0)
+  (set! pat-vars '())
+  (set! rule-label-list '())
+  (set! rule-type-alist '())
+  (set! rule-alist '())
+  (set! rule-hierarchy '())
+)
+
 ;; --------------------
 ;; For rule matching
 
@@ -235,21 +250,6 @@
       (generate-word-seqs ghost-buffer)
       (append-to-sent-seq ghost-buffer)
       (State ghost-curr-proc ghost-buffer)))
-)
-
-;; --------------------
-(define (clear-parsing-states)
-  (set! rule-topic '())
-  (set! initial-urges '())
-  (set! default-urge 0)
-  (set! top-lv-goals '())
-  (set! is-rule-seq? #f)
-  (set! goal-rule-cnt 0)
-  (set! pat-vars '())
-  (set! rule-label-list '())
-  (set! rule-type-alist '())
-  (set! rule-alist '())
-  (set! rule-hierarchy '())
 )
 
 ;; --------------------

--- a/opencog/ghost/terms.scm
+++ b/opencog/ghost/terms.scm
@@ -494,8 +494,6 @@
 )
 
 (define-public (ghost-compare-equal? LV RV)
-; JJJ
-(format #t "LV = ~a\nRV = ~a\n" (flatten-list (cog-outgoing-set LV)) (get-members RV))
   (cond
     ((and (not (null? (gar RV)))
           (equal? 'ConceptNode (cog-type (gar RV)))

--- a/opencog/ghost/terms.scm
+++ b/opencog/ghost/terms.scm
@@ -374,23 +374,6 @@
       (stv 1 1)))
 
 ; ----------
-(define (uvar-equal? UVAR VAL)
-"
-  Check if the value of the user variable VAR equals to VAL.
-"
-  ; TODO: VAL can also be a concept etc?
-  (Evaluation (GroundedPredicate "scm: ghost-user-variable-equal?")
-              (List (ghost-uvar UVAR) (List (Word VAL)))))
-
-(define-public (ghost-user-variable-equal? UVAR VAL)
-"
-  Check if the value of UVAR equals VAL.
-"
-  (if (equal? (assoc-ref uvars UVAR) VAL)
-      (stv 1 1)
-      (stv 0 1)))
-
-; ----------
 (define-public (ghost-execute-action . ACTIONS)
 "
   Execute the actions and update the internal state.
@@ -471,4 +454,123 @@
 
   ; Return an atom
   (True)
+)
+
+; ----------
+(define (compare-equal LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-equal?")
+    (List (List LV) (List RV)))
+)
+
+(define (compare-not-equal LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-not-equal?")
+    (List (List LV) (List RV)))
+)
+
+(define (compare-smaller LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-smaller?")
+    (List (List LV) (List RV)))
+)
+
+(define (compare-smaller-equal LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-smaller-equal?")
+    (List (List LV) (List RV)))
+)
+
+(define (compare-greater LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-greater?")
+    (List (List LV) (List RV)))
+)
+
+(define (compare-greater-equal LV RV)
+  (Evaluation
+    (GroundedPredicate "scm: ghost-compare-greater-equal?")
+    (List (List LV) (List RV)))
+)
+
+(define-public (ghost-compare-equal? LV RV)
+; JJJ
+(format #t "LV = ~a\nRV = ~a\n" (flatten-list (cog-outgoing-set LV)) (get-members RV))
+  (cond
+    ((and (not (null? (gar RV)))
+          (equal? 'ConceptNode (cog-type (gar RV)))
+          (is-member?
+            (flatten-list (cog-outgoing-set LV))
+            (get-members (gar RV))))
+     (stv 1 1))
+    ((compare "equal" LV RV) (stv 1 1))
+    (else (stv 0 1)))
+)
+
+(define-public (ghost-compare-not-equal? LV RV)
+  (define result (ghost-compare-equal? LV RV))
+  (if (equal? result (stv 1 1))
+    (stv 0 1)
+    (stv 1 1))
+)
+
+(define-public (ghost-compare-smaller? LV RV)
+  (if (compare "smaller" LV RV)
+    (stv 1 1)
+    (stv 0 1))
+)
+
+(define-public (ghost-compare-smaller-equal? LV RV)
+  (if (compare "smaller_equal" LV RV)
+    (stv 1 1)
+    (stv 0 1))
+)
+
+(define-public (ghost-compare-greater? LV RV)
+  (if (compare "greater" LV RV)
+    (stv 1 1)
+    (stv 0 1))
+)
+
+(define-public (ghost-compare-greater-equal? LV RV)
+  (if (compare "greater_equal" LV RV)
+    (stv 1 1)
+    (stv 0 1))
+)
+
+(define (compare OPERATOR LV RV)
+  (define lv
+    (if (equal? 'ListLink (cog-type LV))
+      (flatten-list (cog-outgoing-set LV))
+      (list LV)))
+  (define rv
+    (if (equal? 'ListLink (cog-type RV))
+      (flatten-list (cog-outgoing-set RV))
+      (list RV)))
+  (define lv-str (string-join (map cog-name lv)))
+  (define rv-str (string-join (map cog-name rv)))
+  (define lv-num
+    (string->number (string-join (map cog-name lv) "")))
+  (define rv-num
+    (string->number (string-join (map cog-name rv) "")))
+  (define both-numbers? (and lv-num rv-num))
+
+  (cond
+    ((string=? "equal" OPERATOR)
+     (if both-numbers?
+       (= lv-num rv-num)
+       (string=? lv-str rv-str)))
+    ((string=? "smaller" OPERATOR)
+     (and both-numbers?
+          (< lv-num rv-num)))
+    ((string=? "smaller_equal" OPERATOR)
+     (and both-numbers?
+          (<= lv-num rv-num)))
+    ((string=? "greater" OPERATOR)
+     (and both-numbers?
+          (> lv-num rv-num)))
+    ((string=? "greater_equal" OPERATOR)
+     (and both-numbers?
+          (>= lv-num rv-num)))
+    (else #f))
 )

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -285,6 +285,7 @@
             ((equal? 'empty-context (car t))
               (set! c (list (TrueLink))))
             (else (begin
+              (clear-parsing-states)
               (cog-logger-warn ghost-logger
                 "Feature not supported: \"(~a ~a)\"" (car t) (cdr t))
               (throw 'FeatureNotSupported (car t) (cdr t))))))

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -139,6 +139,25 @@
   ; - be related to a particular "concept"
   (define spec-concept 2)
 
+  (define (compare-items i1 i2)
+    (map
+      (lambda (x)
+        (cond
+          ((equal? 'get_uvar (car x))
+           (get-user-variable (cdr x)))
+          ((equal? 'get_wvar (car x))
+           (list-ref pat-vars (cdr x)))
+          ((equal? 'get_lvar (car x))
+           (get-var-lemmas
+             (list-ref pat-vars (cdr x))))
+          ((equal? 'concept (car x))
+           (Concept (cdr x)))
+          ; TODO: function
+          ((equal? 'str (car x))
+           (WordNode (cdr x)))))
+      (list i1 i2))
+  )
+
   (define (process terms)
     (define v '())
     (define c '())
@@ -251,12 +270,6 @@
              ; user variable has been defined
              (set! specificity (+ specificity 1))
              (set! has-words? #t))
-            ((equal? 'uvar_equal (car t))
-             (set! c (append c (list (uvar-equal? (cadr t) (caddr t)))))
-             ; uvar_equal should have a specificity of a word as they
-             ; have the same set of conditions to be satisfied
-             (set! specificity (+ specificity spec-word))
-             (set! has-words? #t))
             ((equal? 'function (car t))
              ; The specificity of a function / predicate depends really
              ; on what that function is doing (and it could be anything)
@@ -283,7 +296,28 @@
             ; it's always true and should be triggered
             ; even if there is no perception input
             ((equal? 'empty-context (car t))
-              (set! c (list (TrueLink))))
+             (set! c (list (TrueLink))))
+            ((equal? 'compare (car t))
+             (set! c (append c (list
+               (cond
+                 ((string=? "equal" (cadr t))
+                  (apply compare-equal
+                    (compare-items (caddr t) (cadddr t))))
+                 ((string=? "not_equal" (cadr t))
+                  (apply compare-not-equal
+                    (compare-items (caddr t) (cadddr t))))
+                 ((string=? "smaller" (cadr t))
+                  (apply compare-smaller
+                    (compare-items (caddr t) (cadddr t))))
+                 ((string=? "smaller_equal" (cadr t))
+                  (apply compare-smaller-equal
+                    (compare-items (caddr t) (cadddr t))))
+                 ((string=? "greater" (cadr t))
+                  (apply compare-greater
+                    (compare-items (caddr t) (cadddr t))))
+                 ((string=? "greater_equal" (cadr t))
+                  (apply compare-greater-equal
+                    (compare-items (caddr t) (cadddr t)))))))))
             (else (begin
               (clear-parsing-states)
               (cog-logger-warn ghost-logger

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -139,23 +139,23 @@
   ; - be related to a particular "concept"
   (define spec-concept 2)
 
-  (define (compare-items i1 i2)
-    (map
-      (lambda (x)
-        (cond
-          ((equal? 'get_uvar (car x))
-           (get-user-variable (cdr x)))
-          ((equal? 'get_wvar (car x))
-           (list-ref pat-vars (cdr x)))
-          ((equal? 'get_lvar (car x))
-           (get-var-lemmas
-             (list-ref pat-vars (cdr x))))
-          ((equal? 'concept (car x))
-           (Concept (cdr x)))
-          ; TODO: function
-          ((equal? 'str (car x))
-           (WordNode (cdr x)))))
-      (list i1 i2))
+  (define (compare-item x)
+    (cond
+      ((equal? 'get_uvar (car x))
+       (get-user-variable (cdr x)))
+      ((equal? 'get_wvar (car x))
+       (list-ref pat-vars (cdr x)))
+      ((equal? 'get_lvar (car x))
+       (get-var-lemmas
+         (list-ref pat-vars (cdr x))))
+      ((equal? 'concept (car x))
+       (Concept (cdr x)))
+      ((equal? 'function (car x))
+       (action-function (cadr x)
+         (map compare-item (cddr x))))
+      ((or (equal? 'str (car x))
+           (equal? 'arg (car x)))
+       (WordNode (cdr x))))
   )
 
   (define (process terms)
@@ -301,23 +301,29 @@
              (set! c (append c (list
                (cond
                  ((string=? "equal" (cadr t))
-                  (apply compare-equal
-                    (compare-items (caddr t) (cadddr t))))
+                  (compare-equal
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t))))
                  ((string=? "not_equal" (cadr t))
-                  (apply compare-not-equal
-                    (compare-items (caddr t) (cadddr t))))
+                  (compare-not-equal
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t))))
                  ((string=? "smaller" (cadr t))
-                  (apply compare-smaller
-                    (compare-items (caddr t) (cadddr t))))
+                  (compare-smaller
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t))))
                  ((string=? "smaller_equal" (cadr t))
-                  (apply compare-smaller-equal
-                    (compare-items (caddr t) (cadddr t))))
+                  (compare-smaller-equal
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t))))
                  ((string=? "greater" (cadr t))
-                  (apply compare-greater
-                    (compare-items (caddr t) (cadddr t))))
+                  (compare-greater
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t))))
                  ((string=? "greater_equal" (cadr t))
-                  (apply compare-greater-equal
-                    (compare-items (caddr t) (cadddr t)))))))))
+                  (compare-greater-equal
+                    (compare-item (caddr t))
+                    (compare-item (cadddr t)))))))))
             (else (begin
               (clear-parsing-states)
               (cog-logger-warn ghost-logger


### PR DESCRIPTION
Support `=` `!=` `<` `<=` `>` `>=` for variables, user variables, and functions, e.g.
```
(^get_arousal() > 0)

(you are _* '_0!=lazy)

(^get_value() <= $threshold)
```