### PR TITLE
Match user variable value in Ghost

### DIFF
--- a/opencog/ghost/README.md
+++ b/opencog/ghost/README.md
@@ -35,6 +35,7 @@ Here is a list of features that are fully supported in GHOST:
 - [Range-restricted Wildcard](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#range-restricted-wildcards-n)
 - [Variable](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#_-match-variables)
 - [User Variable](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#user_variables)
+  - There is one difference, in ChatScript when a user variable is placed in the context, e.g. `?: ( what is my name $firstname ) Your name is $firstname.`, it checks whether `$firstname` has been defined, and trigger the rule if it's been defined and the input is "what is my name". In GHOST, on the contrary, it also checks the value of that user variable against the input to see if they match, e.g. `u: (I'm $name) I know.` and `$name` == "Sam", then rule will only be triggered if the input is "I'm Sam".
 - [Sentence Boundary](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#sentence-boundaries--and-)
 - [Negation](https://github.com/bwilcox-1234/ChatScript/blob/master/WIKI/ChatScript-Basic-User-Manual.md#not--and-notnot-)
   - Currently predicates (functions) are not supported, only accept word, lemma, phrase, and concepts.

--- a/opencog/ghost/cs-parse.scm
+++ b/opencog/ghost/cs-parse.scm
@@ -731,7 +731,7 @@
     )
 
     (user-variable
-      (UVAR) : (format #f "(cons 'uvar_exist \"~a\")" $1)
+      (UVAR) : (format #f "(cons 'uvar_eval \"~a\")" $1)
       (UVAR operator right-compare) :
         (format #f "(cons 'compare (list \"~a\" ~a ~a))"
           $2 (format #f "(cons 'get_uvar \"~a\")" $1) $3)

--- a/opencog/ghost/terms.scm
+++ b/opencog/ghost/terms.scm
@@ -368,9 +368,10 @@
   (True))
 
 ; ----------
-(define (uvar-exist? UVAR)
+(define (uvar-eval UVAR)
 "
-  Check if a user variable has been defined.
+  Check if a user variable has been defined and the value is checked against
+  the input.
 "
   (let* ((g (Glob (gen-var (string-append "user-variable-" UVAR "-grounding") #f)))
          (v (list (TypedVariable g
@@ -379,14 +380,6 @@
                       (Interval (Number 1) (Number -1))))))
          (c (list (compare-equal (get-user-variable UVAR) g))))
     (list v c (list g) (list g))))
-
-(define-public (ghost-user-variable-exist? UVAR)
-"
-  Check if UVAR has been defined.
-"
-  (if (equal? (assoc-ref uvars UVAR) #f)
-      (stv 0 1)
-      (stv 1 1)))
 
 ; ----------
 (define-public (ghost-execute-base-action . ACTIONS)

--- a/opencog/ghost/terms.scm
+++ b/opencog/ghost/terms.scm
@@ -372,8 +372,13 @@
 "
   Check if a user variable has been defined.
 "
-  (Evaluation (GroundedPredicate "scm: ghost-user-variable-exist?")
-              (List (ghost-uvar UVAR))))
+  (let* ((g (Glob (gen-var (string-append "user-variable-" UVAR "-grounding") #f)))
+         (v (list (TypedVariable g
+                    (TypeSet
+                      (Type "WordNode")
+                      (Interval (Number 1) (Number -1))))))
+         (c (list (compare-equal (get-user-variable UVAR) g))))
+    (list v c (list g) (list g))))
 
 (define-public (ghost-user-variable-exist? UVAR)
 "

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -267,7 +267,7 @@
              (update-lists (process (cdr t)))
              (set! pat-vars (append pat-vars (last-pair ws))))
             ((equal? 'uvar_exist (car t))
-             (set! c (append c (list (uvar-exist? (cdr t)))))
+             (update-lists (uvar-exist? (cdr t)))
              ; User variable has a condition of checking if a particular
              ; user variable has been defined
              (set! specificity (+ specificity 1))

--- a/opencog/ghost/translator.scm
+++ b/opencog/ghost/translator.scm
@@ -266,8 +266,8 @@
             ((equal? 'variable (car t))
              (update-lists (process (cdr t)))
              (set! pat-vars (append pat-vars (last-pair ws))))
-            ((equal? 'uvar_exist (car t))
-             (update-lists (uvar-exist? (cdr t)))
+            ((equal? 'uvar_eval (car t))
+             (update-lists (uvar-eval (cdr t)))
              ; User variable has a condition of checking if a particular
              ; user variable has been defined
              (set! specificity (+ specificity 1))


### PR DESCRIPTION
There is a request to change the behavior of putting a user variable in the context of a rule from checking whether it's been defined to matching its value against the input string.