### PR TITLE
Update CMakeLists.txt to export extra headers

### DIFF
--- a/opencog/cogserver/server/CMakeLists.txt
+++ b/opencog/cogserver/server/CMakeLists.txt
@@ -93,6 +93,8 @@ INSTALL (TARGETS server DESTINATION "lib${LIB_DIR_SUFFIX}/opencog")
 
 INSTALL (FILES
 	Agent.h
+	AgentRunnerBase.h
+	AgentRunnerThread.h
 	BaseServer.h
 	CogServer.h
 	ConsoleSocket.h


### PR DESCRIPTION
Recently, I have tried to deploy a session based GHOST service for SNET that uses several CogServers to manage MindAgents for exclusive sessions. Consequently, the included headers are needed in order to allow CogServer object to be created.

Need the following headers to use the CogServer object directly inside a c++ program.
      -AgentRunnnerBase.h
      -AgentRunnerThread.h