### PR TITLE
Rename frequency to support

### DIFF
--- a/opencog/learning/miner/Miner.cc
+++ b/opencog/learning/miner/Miner.cc
@@ -238,12 +238,12 @@ HandleTree Miner::specialize_shapat(const Handle& pattern,
 bool Miner::enough_support(const Handle& pattern,
                            const HandleSet& texts) const
 {
-	return param.minsup <= freq(pattern, texts, param.minsup);
+	return param.minsup <= support(pattern, texts, param.minsup);
 }
 
-unsigned Miner::freq(const Handle& pattern,
-                     const HandleSet& texts,
-                     unsigned ms) const
+unsigned Miner::support(const Handle& pattern,
+                        const HandleSet& texts,
+                        unsigned ms) const
 {
 	HandleSeq cps(MinerUtils::get_component_patterns(pattern));
 
@@ -251,18 +251,18 @@ unsigned Miner::freq(const Handle& pattern,
 	if (cps.empty())
 	    return 1;
 
-	// Otherwise aggregate the frequencies in a heuristic fashion
-	std::vector<unsigned> freqs;
-	boost::transform(cps, std::back_inserter(freqs),
+	// Otherwise aggregate the counts in a heuristic fashion
+	std::vector<unsigned> supports;
+	boost::transform(cps, std::back_inserter(supports),
 	                 [&](const Handle& cp)
 	                 { return MinerUtils::component_support(cp, texts, ms); });
-	return freq(freqs);
+	return support(supports);
 }
 
-unsigned Miner::freq(const std::vector<unsigned>& freqs) const
+unsigned Miner::support(const std::vector<unsigned>& supports) const
 {
-	double minf = *boost::min_element(freqs),
-		timesf = boost::accumulate(freqs, 1, std::multiplies<unsigned>()),
+	double minf = *boost::min_element(supports),
+		timesf = boost::accumulate(supports, 1, std::multiplies<unsigned>()),
 		f = param.info * minf + (1 - param.info) * timesf;
 	return std::floor(f);
 }

--- a/opencog/learning/miner/Miner.h
+++ b/opencog/learning/miner/Miner.h
@@ -54,8 +54,8 @@ struct MinerParameters {
 	                int maxdepth=-1,
 	                double info=1.0);
 
-	// Minimum support. Mined patterns must have a frequency equal or
-	// above this value.
+	// Minimum support. Mined patterns must have a count equal or above
+	// this value.
 	unsigned minsup;
 
 	// Initial number of conjuncts. This value is overwritten by the
@@ -78,34 +78,33 @@ struct MinerParameters {
 	// initial pattern and the produced patterns.
 	int maxdepth;
 
-	// Modify how the frequency of strongly connected components is
-	// calculated from the frequencies of its components. Specifically
-	// it will go from f1*...*fn to min(f1,...,fn), where f1 to fn are
-	// the frequencies of each component. This allows to dismiss
-	// abstractions that are likely not to lead to specializations
-	// with enough support.
+	// Experimental: modify how the count (a.k.a. support) of strongly
+	// connected components is calculated from the counts of its
+	// components. Specifically it will go from c1*...*cn to
+	// min(c1,...,cn), where c1 to cn are the counts of each
+	// component. This allows to dismiss abstractions that are likely
+	// not to lead to specializations with enough support.
 	//
-	// If the parameter equals to 0 the frequency of the whole pattern
-	// is calculated as the product of f1 to fn, if it equals to 1 the
-	// frequency of the whole pattern is calculated as the min of f1
-	// to fn. And if the value is between, it is calculated as a
-	// linear combination of both.
+	// If the parameter equals to 0 the count of the whole pattern is
+	// calculated as the product of c1 to cn, if it equals to 1 the
+	// count of the whole pattern is calculated as the min of c1 to
+	// cn. And if the value is between, it is calculated as a linear
+	// combination of both.
 	//
 	// It is called info for mutual information or its n-ary
-	// generalizations (like interaction information). What it means
-	// is that when info is low subsequent specializations are likely
+	// generalizations (like interaction information). What it means is
+	// that when info is low subsequent specializations are likely
 	// independant, while when info is high subsequent specializations
 	// are likely dependant and thus we can afford to estimate the
-	// frequency of the specializations by the lowest frequency of its
+	// count of the specializations by the lowest count of its
 	// component.
 	double info;
 };
 
 /**
- * Experimental pattern miner. Mined patterns should be compatible
- * with the pattern matcher, that is if feed to the pattern matcher,
- * the latter should return as many candidates as the pattern's
- * frequency.
+ * Pattern miner. Mined patterns should be compatible with the pattern
+ * matcher, that is if feed to the pattern matcher, the latter should
+ * return as many candidates as the pattern's count.
  */
 class Miner
 {
@@ -120,8 +119,8 @@ public:
 	/**
 	 * Mine the given AtomSpace and return a tree of patterns linked by
 	 * specialization relationship (children are specializations of
-	 * parent) with frequency equal to or above minsup, starting from
-	 * the initial pattern, excluded.
+	 * parent) with count (a.k.a. support) equal to or above minsup,
+	 * starting from the initial pattern, excluded.
 	 */
 	HandleTree operator()(const AtomSpace& texts_as);
 
@@ -195,34 +194,33 @@ private:
 
 	/**
 	 * Calculate if the pattern has enough support w.r.t. to the given
-	 * texts, that is whether its frequency is greater than or equal
-	 * to minsup.
+	 * texts, that is whether its count is greater than or equal to
+	 * minsup.
 	 */
 	bool enough_support(const Handle& pattern,
 	                    const HandleSet& texts) const;
 
 	/**
-	 * Given a pattern and a text corpus, calculate the pattern
-	 * frequency, that is the number of matches if pattern is strongly
-	 * connected.
+	 * Given a pattern and a text corpus, calculate the pattern count,
+	 * that is the number of matches if pattern is strongly connected.
 	 *
-	 * If pattern is not strongly connected AND some heuristic is in
-	 * place TODO, then the definition of frequency deviates from the
-	 * usual one and corresponds to the minimum frequency over all
-	 * strongly connected components of that pattern.
+	 * If pattern is not strongly connected and some heuristic is in
+	 * place, then the definition of count deviates from the usual one
+	 * and corresponds to the minimum count over all strongly connected
+	 * components of that pattern.
 	 *
-	 * ms is used to halt the frequency calculation if it reaches a
-	 * certain maximum, for saving resources.
+	 * ms is used to halt the count calculation if it reaches a certain
+	 * maximum, for saving resources.
 	 */
-	unsigned freq(const Handle& pattern,
-	              const HandleSet& texts,
-	              unsigned ms) const;
+	unsigned support(const Handle& pattern,
+	                 const HandleSet& texts,
+	                 unsigned ms) const;
 
 	/**
-	 * Calculate the frequency of the whole pattern, given the
-	 * frequency of it's components.
+	 * Calculate the count of the whole pattern, given the count of
+	 * it's components.
 	 */
-	unsigned freq(const std::vector<unsigned>& freqs) const;
+	unsigned support(const std::vector<unsigned>& supports) const;
 
 	/**
 	 * Filter in only texts matching the pattern

--- a/opencog/learning/miner/MinerUtils.cc
+++ b/opencog/learning/miner/MinerUtils.cc
@@ -354,14 +354,14 @@ unsigned MinerUtils::support(const Handle& pattern,
 	if (cps.empty())
 	    return 1;
 
-	// Otherwise calculate the frequency of each component
-	std::vector<unsigned> freqs;
-	boost::transform(cps, std::back_inserter(freqs),
+	// Otherwise calculate the support of each component
+	std::vector<unsigned> supports;
+	boost::transform(cps, std::back_inserter(supports),
 	                 [&](const Handle& cp)
 	                 { return component_support(cp, texts, ms); });
 
-	// Return the product of all frequencies
-	return boost::accumulate(freqs, 1, std::multiplies<unsigned>());
+	// Return the product of all supports
+	return boost::accumulate(supports, 1, std::multiplies<unsigned>());
 }
 
 unsigned MinerUtils::component_support(const Handle& component,

--- a/opencog/learning/miner/MinerUtils.h
+++ b/opencog/learning/miner/MinerUtils.h
@@ -202,7 +202,7 @@ public:
 
 	/**
 	 * Given a pattern and a text corpus, calculate the pattern
-	 * frequency up to ms (to avoid unnecessary calculations).
+	 * support up to ms (to avoid unnecessary calculations).
 	 */
 	static unsigned support(const Handle& pattern,
 	                        const HandleSet& texts,
@@ -218,8 +218,8 @@ public:
 
 	/**
 	 * Calculate if the pattern has enough support w.r.t. to the given
-	 * texts, that is whether its frequency is greater than or equal
-	 * to ms.
+	 * texts, that is whether its support is greater than or equal to
+	 * ms.
 	 */
 	static bool enough_support(const Handle& pattern,
 	                           const HandleSet& texts,

--- a/opencog/learning/miner/README.md
+++ b/opencog/learning/miner/README.md
@@ -28,18 +28,20 @@ Let us recall the important terms
 * *Text tree*: a tree (or hypergraph) that is part of the data set to
   be mined. Can be imply called *tree*. Generally speaking any atom of
   an atomspace.
+* *Database*: a set of text tree to mine.
 * *Pattern tree*: a tree representing a pattern, that is capturing a
   collection of text trees. Can be simply called *pattern*.
-* *Frequency*: number of text trees and subtrees matching a given
+* *Support*: number of text trees and subtrees matching a given
   pattern.
-* *Support*: similar to frequency.
+* *Count*: another word for *support*.
+* *Frequency*: Support divided by the size of the database.
 * *Minimum support*: parameter of the mining algorithm to discard
-  patterns with frequency below that value.
+  patterns with support below that value.
 * *A priori property*: assumption that allows to systematically prune
   the search space. In its least abstract form, it expresses the fact
-  that if a pattern tree has a certain frequency `f` then a
-  specialization of it can only have a frequency that is equal to or
-  lower than `f`.
+  that if a pattern tree has a certain support `c` then a
+  specialization of it can only have a support that is equal to or
+  lower than `c`.
 
 Algorithm
 ---------
@@ -47,8 +49,8 @@ Algorithm
 Patterm mining operates by searching the space of pattern trees,
 typically starting from the most abstract pattern, the one that
 encompass all text trees, construct specializations of it, retain
-those that have enough support (frequency equal to or above the
-minimum support), then recursively specialize those, and so on.
+those that have enough support (count equal to or above the minimum
+support), then recursively specialize those, and so on.
 
 ### Pattern Trees in Atomese
 
@@ -324,7 +326,7 @@ See https://wiki.opencog.org/w/PutLink for more information about `PutLink`.
 #### Step 5: Add Resulting Specializations with Enough Support
 
 Given all specializations (6 in total in this iteration example), we
-now need to calculate the frequency of each of them against `T`, and
+now need to calculate the support of each of them against `T`, and
 only the one reaching the minimum support can be added back to the
 population of patterns `C`. Out of these 6 only one has enough support
 ```scheme
@@ -531,7 +533,7 @@ meaning that if `Ps` has enough support and is a specialization of
 `P`, then `P` has enough support. And a second rule to evaluate by
 direct calculation if some pattern has enough support
 ```
-ms <= freq(P, T)
+ms <= support(P, T)
 |-
 minsup(P, T, ms)
 ```
@@ -711,9 +713,9 @@ TODO
 1. Support surprisingness.
 2. Support links such as `DefineLink`, `DefinedSchemaNode`,
    `ExecutionOutputLink`, etc.
-3. Store more information about the pattern, such as frequency and
-   surprisingness, and make accessible to the user. Maybe store this
-   as values attached to patterns.
+3. Store more information about the pattern, such as support,
+   frequency and surprisingness, and make accessible to the
+   user. Maybe store this as values attached to patterns.
 
 References
 ----------

--- a/opencog/learning/miner/miner-utils.scm
+++ b/opencog/learning/miner/miner-utils.scm
@@ -342,7 +342,7 @@
               tn
               (Concept texts-name))
 
-  ms: [optional, default=10] Minimum support. All patterns with frequency below
+  ms: [optional, default=10] Minimum support. All patterns with support below
       ms are discarded. Can be a Scheme number or an Atomese number node.
 
   ip: [optional, default=(top)] Initial pattern to start the search from.

--- a/opencog/learning/miner/rules/specialization.scm
+++ b/opencog/learning/miner/rules/specialization.scm
@@ -56,7 +56,7 @@
 ;;     <ms>
 ;;
 ;; assuming that tv1 and tv2 are equal to (stv 1 1), then calculate
-;; the frequency of the composed pattern and set tv3 accordingly, (stv
+;; the support of the composed pattern and set tv3 accordingly, (stv
 ;; 1 1) if g composed with f has support ms, (stv 0 1) otherwise.
 ;;
 ;; <f> may either a pattern with one link all variables as outgoings,


### PR DESCRIPTION
Indeed, according to the usual terminology, support means count, not
frequency, the latter means pattern count divided by database count.