### PR TITLE
print link-weight values in parses

### DIFF
--- a/opencog/nlp/learn/run-poc/redefine-mst-parser.scm
+++ b/opencog/nlp/learn/run-poc/redefine-mst-parser.scm
@@ -91,11 +91,12 @@
 		(lambda (l) ; links
 			(if (> (get-mi l) -1.0e10) ; bad-MI
 				(display
-					(format #f "~a ~a ~a ~a\n"
+					(format #f "~a ~a ~a ~a ~a\n"
 						(get-lindex l)
 						(get-lword l)
 						(get-rindex l)
-						(get-rword l))
+						(get-rword l)
+						(get-mi l))
 				file-port)))
 		(sort mstparse link-comparator)
 	)


### PR DESCRIPTION
Links from parses exported in the ULL pipeline now include a fifth column: the given link's weight.