### PR TITLE
Add link to repo with docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ To build and run OpenCog, the packages listed below are required.
 With a few exceptions, most Linux distributions will provide these
 packages. Users of Ubuntu may use the dependency installer from the
 `/opencog/octool` repository.  Users of any version of Linux may
-use the Dockerfile to quickly build a container in which OpenCog will
+use the 
+[Dockerfile](https://github.com/opencog/docker/blob/master/opencog/README.md) 
+to quickly build a container in which OpenCog will
 be built and run.
 
 ###### cogutil


### PR DESCRIPTION
It took me a few minutes to find where the docker container files where, as I was looking in this same repo